### PR TITLE
Nested AVRO records in the Schema

### DIFF
--- a/src/main/java/io/kestra/plugin/pulsar/GenericRecordProducer.java
+++ b/src/main/java/io/kestra/plugin/pulsar/GenericRecordProducer.java
@@ -1,12 +1,14 @@
 package io.kestra.plugin.pulsar;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.api.schema.*;
-import org.apache.pulsar.client.impl.schema.generic.GenericAvroSchema;
-import org.apache.pulsar.client.impl.schema.generic.GenericJsonSchema;
-import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
+import org.apache.pulsar.client.impl.schema.generic.*;
 
 import io.kestra.core.runners.RunContext;
 
@@ -46,13 +48,42 @@ public class GenericRecordProducer extends AbstractProducer<GenericRecord> {
         TypedMessageBuilder<GenericRecord> message = producer.newMessage();
 
         if (renderedMap.containsKey("value")) {
-            GenericSchemaImpl schema = this.schemaType == SchemaType.AVRO ? GenericAvroSchema.of(this.schema.getSchemaInfo()) : GenericJsonSchema.of(this.schema.getSchemaInfo());
-            org.apache.pulsar.client.api.schema.GenericRecordBuilder record = schema.newRecordBuilder();
+          // For AVRO schemas we need to load the native schema to check if we need to denest any records types
+          org.apache.pulsar.shade.org.apache.avro.Schema nativeSchema = this.schemaType == SchemaType.AVRO ? ((org.apache.pulsar.shade.org.apache.avro.Schema)this.schema.getNativeSchema().get()) : null;
+
+          
+          GenericSchemaImpl schema = this.schemaType == SchemaType.AVRO ? GenericAvroSchema.of(this.schema.getSchemaInfo()) : GenericJsonSchema.of(this.schema.getSchemaInfo());
+          GenericRecordBuilder record = schema.newRecordBuilder();
             Map<String, Object> value = (Map<String, Object>)renderedMap.get("value");
-            value.forEach((k,v) -> record.set(k, v));
+            value.forEach((k,v) -> record.set(k, this.schemaType == SchemaType.AVRO ? denestRecord(v, nativeSchema.getField(k).schema()): v));
             message.value(record.build());
         }
 
         return message;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private Object denestRecord(Object value, org.apache.pulsar.shade.org.apache.avro.Schema schema) {      
+      switch(schema.getType()) {
+        case RECORD:
+          // This doesn't work for user-defined class objects. However, given values are inputs from Kestra they should all be maps
+          org.apache.pulsar.shade.org.apache.avro.generic.GenericRecord record = new org.apache.pulsar.shade.org.apache.avro.generic.GenericData.Record(schema);
+          for (Map.Entry<String, Object> entry : ((Map<String, Object>)value).entrySet())
+            record.put(entry.getKey(), denestRecord(entry.getValue(), schema.getField(entry.getKey()).schema()));
+          return record;
+        case ARRAY:
+          List<Object> list = new ArrayList<Object>();
+          for (Object x : (Iterable<Object>)value) {
+            list.add(denestRecord(x, schema.getElementType()));
+          }
+          return list;
+        case MAP:
+          HashMap<String, Object> map = new HashMap<>();
+          for (Map.Entry<String, Object> entry : ((Map<String, Object>)value).entrySet())
+            map.put(entry.getKey(), denestRecord(entry.getValue(), schema.getValueType()));
+          return map;
+        default:
+          return value;
+      }
     }
 }


### PR DESCRIPTION
This extends the work in #38 to handle when the schema has nested `record` types which would previously throw an error. 

Essentially the bug was that AVRO was expecting a `record` type which is a representation of an object but was receiving a HashMap of the object instead (as data comes from Kestra as a map)

It is fixed by implementing a recursive function on the `value` of the field; replacing the HashMap with a nested `GenericRecord`. It works for when the `record` type is by itself, as part of an array, or another HashMap.

Tests have been added and should be passing