### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=1.3.3-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19
 org.gradle.jvmargs=-Xmx2g

--- a/src/main/java/io/kestra/plugin/pulsar/AbstractProducer.java
+++ b/src/main/java/io/kestra/plugin/pulsar/AbstractProducer.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.pulsar;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
 import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -112,7 +111,7 @@ public abstract class AbstractProducer<T> {
             Flux<Integer> resultFlowable;
             if (from instanceof String) {
                 URI uri = new URI(runContext.render((String) from));
-                try (BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(uri)))) {
+                try (BufferedInputStream inputStream = new BufferedInputStream(runContext.storage().getFile(uri), FileSerde.BUFFER_SIZE)) {
                     flowable = FileSerde.readAll(inputStream);
                     resultFlowable = this.buildFlowable(flowable);
 

--- a/src/test/java/io/kestra/plugin/pulsar/PulsarTest.java
+++ b/src/test/java/io/kestra/plugin/pulsar/PulsarTest.java
@@ -87,9 +87,9 @@ public class PulsarTest {
         Consume.Output consumeOutput = consume.run(runContext);
         assertThat(consumeOutput.getMessagesCount(), is(50));
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, consumeOutput.getUri())));
+        BufferedInputStream inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, consumeOutput.getUri()), FileSerde.BUFFER_SIZE);
         List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
+        FileSerde.read(inputStream, r -> result.add((Map<String, Object>) r));
 
         assertThat(result.size(), is(50));
 
@@ -124,9 +124,9 @@ public class PulsarTest {
         Reader.Output consumeOutput = reader.run(runContext);
         assertThat(consumeOutput.getMessagesCount(), is(50));
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, consumeOutput.getUri())));
+        BufferedInputStream inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, consumeOutput.getUri()), FileSerde.BUFFER_SIZE);
         List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
+        FileSerde.read(inputStream, r -> result.add((Map<String, Object>) r));
 
         assertThat(result.size(), is(50));
 


### PR DESCRIPTION
Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155).

## Changes
- Bump `kestraVersion` to `1.3.19`
- `AbstractProducer.java`: replace `BufferedReader`/`InputStreamReader` + `FileSerde.readAll(reader)` with `BufferedInputStream` + `FileSerde.readAll(inputStream)`
- `PulsarTest.java`: replace `BufferedReader`/`InputStreamReader` + `FileSerde.reader()` with `BufferedInputStream` + `FileSerde.read()`
- `AbstractReader.java`: already uses OutputStream-based API, no changes needed