### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/pulsar/AbstractPulsarConnection.java
+++ b/src/main/java/io/kestra/plugin/pulsar/AbstractPulsarConnection.java
@@ -16,6 +16,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 public abstract class AbstractPulsarConnection extends Task implements PulsarConnectionInterface {
     private Property<String> uri;
 
+    @ToString.Exclude
     private Property<String> authenticationToken;
 
     private TlsOptions tlsOptions;
@@ -37,6 +38,7 @@ public abstract class AbstractPulsarConnection extends Task implements PulsarCon
 
     @Value
     public static class TlsOptions {
+        @ToString.Exclude
         @Schema(
             title = "Client certificate",
             description = "Base64-encoded PEM content for the client certificate."
@@ -44,6 +46,7 @@ public abstract class AbstractPulsarConnection extends Task implements PulsarCon
         )
         Property<String> cert;
 
+        @ToString.Exclude
         @Schema(
             title = "Client key",
             description = "Base64-encoded PEM private key matching the client certificate."


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — authenticationToken exposed via Lombok `@ToString` on `AbstractPulsarConnection` — `src/main/java/io/kestra/plugin/pulsar/AbstractPulsarConnection.java:19` — Added `@ToString.Exclude` to the `authenticationToken` field so Lombok's generated `toString()` no longer renders the raw token (the existing `@PluginProperty(secret=true)` on the interface getter does not suppress field-based `@ToString` output).
- **MEDIUM** — TLS private key (`TlsOptions.key`) and cert exposed via Lombok `@Value @ToString` — `src/main/java/io/kestra/plugin/pulsar/AbstractPulsarConnection.java:52` — Added `@ToString.Exclude` to both the `cert` and `key` fields of the `TlsOptions` inner class so the certificate/private key material is excluded from the generated `toString()` output.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-pulsar/issues/182
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
